### PR TITLE
use std by default instead of eastl

### DIFF
--- a/include/sqrat/sqratArray.h
+++ b/include/sqrat/sqratArray.h
@@ -291,7 +291,7 @@ struct Var<Array> {
         value = Array(obj, vm);
         SQObjectType value_type = sq_gettype(vm, idx);
         if (value_type != OT_ARRAY && value_type != OT_NULL) {
-          SQRAT_ASSERTF(0, FormatTypeError(vm, idx, _SC("array")).c_str());
+            SQRAT_ASSERTF(0, FormatTypeError(vm, idx, _SC("array")).c_str());
         }
     }
 

--- a/include/sqrat/sqratClass.h
+++ b/include/sqrat/sqratClass.h
@@ -106,7 +106,7 @@ public:
             if (ClassType<C>::getStaticClassData().expired()) {
                 cd->staticData.reset(new StaticClassData<C, void>);
                 cd->staticData->copyFunc  = &A::Copy;
-                cd->staticData->className = eastl::move(className);
+                cd->staticData->className = SQRAT_STD::move(className);
                 cd->staticData->baseClass = NULL;
 
                 ClassType<C>::getStaticClassData() = cd->staticData;
@@ -415,7 +415,7 @@ protected:
 
     // Initialize the required data structure for the class
     void InitClass(ClassData<C>* cd) {
-        cd->instances.reset(new typename unordered_map<C*, HSQOBJECT>::type);
+        cd->instances.reset(new InstancesMap<C>);
 
         // push the class
         sq_pushobject(vm, cd->classObj);
@@ -643,7 +643,7 @@ public:
             if (ClassType<C>::getStaticClassData().expired()) {
                 cd->staticData.reset(new StaticClassData<C, B>);
                 cd->staticData->copyFunc  = &A::Copy;
-                cd->staticData->className = eastl::move(className);
+                cd->staticData->className = SQRAT_STD::move(className);
                 cd->staticData->baseClass = bd->staticData.get();
 
                 ClassType<C>::getStaticClassData() = cd->staticData;
@@ -666,7 +666,7 @@ public:
 protected:
 
     void InitDerivedClass(ClassData<C>* cd, ClassData<B>* bd) {
-        cd->instances.reset(new typename unordered_map<C*, HSQOBJECT>::type);
+        cd->instances.reset(new InstancesMap<C>);
 
         // push the class
         sq_pushobject(vm, cd->classObj);

--- a/include/sqrat/sqratFunction.h
+++ b/include/sqrat/sqratFunction.h
@@ -63,9 +63,9 @@ public:
 
     Function(Function&& sf) : Function()
     {
-      eastl::swap(vm, sf.vm);
-      eastl::swap(env, sf.env);
-      eastl::swap(obj, sf.obj);
+      SQRAT_STD::swap(vm, sf.vm);
+      SQRAT_STD::swap(env, sf.env);
+      SQRAT_STD::swap(obj, sf.obj);
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -119,9 +119,9 @@ public:
     Function& operator=(Function&& sf)
     {
       Release();
-      eastl::swap(vm, sf.vm);
-      eastl::swap(env, sf.env);
-      eastl::swap(obj, sf.obj);
+      SQRAT_STD::swap(vm, sf.vm);
+      SQRAT_STD::swap(env, sf.env);
+      SQRAT_STD::swap(obj, sf.obj);
       return *this;
     }
 
@@ -223,10 +223,10 @@ public:
           return false;
       }
 
-      typedef typename eastl::remove_reference<
+      typedef typename SQRAT_STD::remove_reference<
                           vargs::TailElem_t<ArgsAndRet...>>::type R;
 
-      R& ret = vargs::tail(eastl::forward<ArgsAndRet>(args_and_ret)...);
+      R& ret = vargs::tail(SQRAT_STD::forward<ArgsAndRet>(args_and_ret)...);
       ret = Var<R>(vm, -1).value;
       sq_settop(vm, top);
       return true;

--- a/include/sqrat/sqratGlobalMethods.h
+++ b/include/sqrat/sqratGlobalMethods.h
@@ -32,7 +32,6 @@
 
 #include <squirrel.h>
 #include "sqratTypes.h"
-#include <EASTL/functional.h>
 
 namespace Sqrat {
 

--- a/include/sqrat/sqratMemberMethods.h
+++ b/include/sqrat/sqratMemberMethods.h
@@ -155,7 +155,7 @@ inline SQInteger sqDefaultSet(HSQUIRRELVM vm) {
     sq_getuserdata(vm, -1, (SQUserPointer*)&memberPtr, NULL); // Get Member...
     M member = *memberPtr;
 
-    if (eastl::is_pointer<V>::value || eastl::is_reference<V>::value) {
+    if (SQRAT_STD::is_pointer<V>::value || SQRAT_STD::is_reference<V>::value) {
         ptr->*member = Var<V>(vm, 2).value;
     } else {
         ptr->*member = Var<const V&>(vm, 2).value;
@@ -171,7 +171,7 @@ inline SQInteger sqStaticSet(HSQUIRRELVM vm) {
     sq_getuserdata(vm, -1, (SQUserPointer*)&memberPtr, NULL); // Get Member...
     M member = *memberPtr;
 
-    if (eastl::is_pointer<V>::value || eastl::is_reference<V>::value) {
+    if (SQRAT_STD::is_pointer<V>::value || SQRAT_STD::is_reference<V>::value) {
         *member = Var<V>(vm, 2).value;
     } else {
         *member = Var<const V&>(vm, 2).value;
@@ -195,7 +195,7 @@ inline SQInteger sqVarSet(HSQUIRRELVM vm) {
     // Call the setter
     SQRESULT result = sq_call(vm, 2, false, SQTrue);
     return SQ_SUCCEEDED(result) ? 0 : SQ_ERROR;
-    }
+}
 
 
 }

--- a/include/sqrat/sqratObject.h
+++ b/include/sqrat/sqratObject.h
@@ -32,7 +32,6 @@
 #include <squirrel.h>
 #include <sqdirect.h>
 #include <string.h>
-#include <EASTL/type_traits.h>
 
 #include "sqratAllocator.h"
 #include "sqratTypes.h"
@@ -88,52 +87,52 @@ public:
     /// \tparam T       Type
     ///
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    template <class T, typename eastl::disable_if<eastl::is_arithmetic<T>::value, bool>::type = false>
+    template <class T, typename disable_if<SQRAT_STD::is_arithmetic<T>::value, bool>::type = false>
     Object(const T &t, HSQUIRRELVM v) : vm(v), release(true) {
-      Var<T>::push(vm, t);
-      SQRAT_VERIFY(SQ_SUCCEEDED(sq_getstackobj(vm, -1, &obj)));
-      sq_addref(vm, &obj);
-      sq_poptop(vm);
-    }
-
-    Object(const SQChar *str, HSQUIRRELVM v, SQInteger str_len = -1) : vm(v), release(true) {
-      if (str) {
-        sq_pushstring(vm, str, str_len);
+        Var<T>::push(vm, t);
         SQRAT_VERIFY(SQ_SUCCEEDED(sq_getstackobj(vm, -1, &obj)));
         sq_addref(vm, &obj);
         sq_poptop(vm);
-      }
-      else
-        sq_resetobject(&obj);
     }
 
-    template <class T, typename eastl::enable_if<(eastl::is_integral<T>::value && !eastl::is_same<T, bool>::value), bool>::type = false>
-    Object(T t, HSQUIRRELVM v) : vm(v), release(false) {
-      obj._type = OT_INTEGER;
-      obj._unVal.nInteger = (SQInteger)t;
+    Object(const SQChar *str, HSQUIRRELVM v, SQInteger str_len = -1) : vm(v), release(true) {
+        if (str) {
+            sq_pushstring(vm, str, str_len);
+            SQRAT_VERIFY(SQ_SUCCEEDED(sq_getstackobj(vm, -1, &obj)));
+            sq_addref(vm, &obj);
+            sq_poptop(vm);
+        }
+        else
+            sq_resetobject(&obj);
     }
 
-    template <class T, typename eastl::enable_if<eastl::is_floating_point<T>::value, bool>::type = false>
+    template <class T, typename SQRAT_STD::enable_if<(SQRAT_STD::is_integral<T>::value && !SQRAT_STD::is_same<T, bool>::value), bool>::type = false>
     Object(T t, HSQUIRRELVM v) : vm(v), release(false) {
-      obj._type = OT_FLOAT;
-      obj._unVal.fFloat = (SQFloat)t;
+        obj._type = OT_INTEGER;
+        obj._unVal.nInteger = (SQInteger)t;
     }
 
-    template <class T, typename eastl::enable_if<eastl::is_same<T, bool>::value, bool>::type = false>
+    template <class T, typename SQRAT_STD::enable_if<SQRAT_STD::is_floating_point<T>::value, bool>::type = false>
     Object(T t, HSQUIRRELVM v) : vm(v), release(false) {
-      obj._type = OT_BOOL;
-      obj._unVal.nInteger = t ? 1 : 0;
+        obj._type = OT_FLOAT;
+        obj._unVal.fFloat = (SQFloat)t;
+    }
+
+    template <class T, typename SQRAT_STD::enable_if<SQRAT_STD::is_same<T, bool>::value, bool>::type = false>
+    Object(T t, HSQUIRRELVM v) : vm(v), release(false) {
+        obj._type = OT_BOOL;
+        obj._unVal.nInteger = t ? 1 : 0;
     }
 
     virtual ~Object() {
-        if(release) {
+        if (release) {
             Release();
             release = false;
         }
     }
 
     Object& operator=(const Object& so) {
-        if(release) {
+        if (release) {
             Release();
         }
         vm = so.vm;

--- a/include/sqrat/sqratOverloadMethods.h
+++ b/include/sqrat/sqratOverloadMethods.h
@@ -31,7 +31,6 @@
 
 #include <squirrel.h>
 #include <sqstdaux.h>
-#include <EASTL/string.h>
 #include "sqratTypes.h"
 #include "sqratUtil.h"
 #include "sqratGlobalMethods.h"
@@ -45,7 +44,9 @@ class SqOverloadName {
 public:
 
     static string Get(const SQChar* name, int args) {
-      string overloadName(string::CtorSprintf(), _SC("__overload_%s%d"), name, args);
+      int l = SQRAT_SPRINTF(nullptr, 0, _SC("__overload_%s%d"), name, args);
+      string overloadName(l+1, '\0');
+      SQRAT_SPRINTF(&overloadName[0], overloadName.size(), _SC("__overload_%s%d"), name, args);
       return overloadName;
     }
 };

--- a/include/sqrat/sqratScript.h
+++ b/include/sqrat/sqratScript.h
@@ -35,7 +35,6 @@
 
 #include "sqratObject.h"
 
-#include <EASTL/string_view.h>
 
 namespace Sqrat {
 
@@ -54,8 +53,8 @@ public:
     /// \param name   Optional string containing the script's name (for errors)
     ///
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    bool CompileString(const eastl::string_view &script, string &errMsg,
-                       const eastl::string_view &name = eastl::string_view())
+    bool CompileString(const string_view &script, string &errMsg,
+                       const string_view &name = string_view())
     {
         if(!sq_isnull(obj)) {
             sq_release(vm, &obj);


### PR DESCRIPTION
this allows to use sqrat without any additional dependencies.
but eastl still can be enabled by defining SQRAT_HAS_EASTL in
sqratConfig.h