### PR TITLE
added missing copy/move ctors and operator= (required after custom dtor)

### DIFF
--- a/include/sqrat/sqratClassType.h
+++ b/include/sqrat/sqratClassType.h
@@ -64,9 +64,9 @@ struct AbstractStaticClassData {
     AbstractStaticClassData() {
         _ClassType_helper<>::all_classes.insert(this);
     }
-    AbstractStaticClassData(const AbstractStaticClassData &) = default;
+    AbstractStaticClassData(const AbstractStaticClassData &) = delete;
     AbstractStaticClassData(AbstractStaticClassData &&) = default;
-    AbstractStaticClassData& operator=(const AbstractStaticClassData &) = default;
+    AbstractStaticClassData& operator=(const AbstractStaticClassData &) = delete;
     AbstractStaticClassData& operator=(AbstractStaticClassData &&) = default;
     virtual ~AbstractStaticClassData() {
         _ClassType_helper<>::all_classes.erase(this);


### PR DESCRIPTION
to be able to compile with vc2022 (with C5267 warning turned on)